### PR TITLE
fix: broken jitpack.io releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'com.github.IPECTER:RTUBiomeLib:1.5.2'
+  implementation 'com.github.ipecter:RTUBiomeLib:1.5.2'
 }
 ```
 
@@ -59,7 +59,7 @@ Maven
 </repositories>
 
 <dependency>
-    <groupId>com.github.IPECTER</groupId>
+    <groupId>com.github.ipecter</groupId>
     <artifactId>RTUBiomeLib</artifactId>
     <version>1.5.2</version>
 </dependency>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'com.github.IPECTER.RTUBiomeLib:RTUBiomeLib:1.5.2'
+  implementation 'com.github.ipecter:RTUBiomeLib:1.5.2'
 }
 ```
 
@@ -59,7 +59,7 @@ Maven
 </repositories>
 
 <dependency>
-    <groupId>com.github.IPECTER.RTUBiomeLib</groupId>
+    <groupId>com.github.ipecter</groupId>
     <artifactId>RTUBiomeLib</artifactId>
     <version>1.5.2</version>
 </dependency>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'com.github.ipecter:RTUBiomeLib:1.5.2'
+  implementation 'com.github.IPECTER:RTUBiomeLib:1.5.2'
 }
 ```
 
@@ -59,7 +59,7 @@ Maven
 </repositories>
 
 <dependency>
-    <groupId>com.github.ipecter</groupId>
+    <groupId>com.github.IPECTER</groupId>
     <artifactId>RTUBiomeLib</artifactId>
     <version>1.5.2</version>
 </dependency>

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ processResources {
 publishing {
     publications {
         maven(MavenPublication) {
-            groupId = 'com.github.IPECTER'
+            groupId = 'com.github.ipecter'
             artifactId = 'RTUBiomeLib'
             version = project.version
 

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ processResources {
 publishing {
     publications {
         maven(MavenPublication) {
-            groupId = 'com.github.ipecter'
+            groupId = 'com.github.IPECTER'
             artifactId = 'RTUBiomeLib'
             version = project.version
 

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ processResources {
 publishing {
     publications {
         maven(MavenPublication) {
-            groupId = 'com.github.IPECTER.RTUBiomeLib'
+            groupId = 'com.github.ipecter'
             artifactId = 'RTUBiomeLib'
             version = project.version
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'maven-publish'
 }
 
 ConfigurableFileTree libsImplementation = fileTree(dir: 'libs-implementation', include: ['*.jar'])
@@ -110,5 +111,17 @@ processResources {
     filteringCharset 'UTF-8'
     filesMatching('plugin.yml') {
         expand props
+    }
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = 'com.github.IPECTER.RTUBiomeLib'
+            artifactId = 'RTUBiomeLib'
+            version = project.version
+
+            from components.java
+        }
     }
 }


### PR DESCRIPTION
The last two releases were not published on Jitpack because they failed to build. This fixes Jitpack releases. I tested it here <https://jitpack.io/#darksaid98/RTUBiomeLib/>. 

~~The last commit also ensures the release is under your group id, not your group id with a capitalized name and the resource name after.~~ I removed `RTUBiomeLib` from the group id.


It might be a good idea to document that change so users can still retrieve old versions from Jitpack.